### PR TITLE
Fix missing elements in ModulatedHenonMap

### DIFF
--- a/xnlbd/track/elements.py
+++ b/xnlbd/track/elements.py
@@ -352,6 +352,7 @@ class ModulatedHenonmap(BeamElement):
         "sin_omega_y": xo.Float64[:],
         "cos_omega_y": xo.Float64[:],
         "n_turns": xo.Int64,
+        "n_par_multipoles": xo.Int64,
         "twiss_params": xo.Float64[:],
         "domegax": xo.Float64,
         "domegay": xo.Float64,
@@ -405,6 +406,7 @@ class ModulatedHenonmap(BeamElement):
             kwargs.setdefault("sin_omega_y", np.sin(omega_y))
             kwargs.setdefault("cos_omega_y", np.cos(omega_y))
             kwargs.setdefault("n_turns", len(omega_x))
+            kwargs.setdefault("n_par_multipoles", len(multipole_coeffs))
             kwargs.setdefault("twiss_params", twiss_params)
             kwargs.setdefault("domegax", 2 * np.pi * dqx)
             kwargs.setdefault("domegay", 2 * np.pi * dqy)
@@ -417,8 +419,7 @@ class ModulatedHenonmap(BeamElement):
             fy_coeffs = []
             fy_x_exps = []
             fy_y_exps = []
-            for i in range(len(omega_x)):
-                curr_multipole_coeffs = multipole_coeffs[i]
+            for i, curr_multipole_coeffs in enumerate(multipole_coeffs):
                 for n in range(2, len(curr_multipole_coeffs) + 2):
                     for k in range(0, n + 1):
                         if (k % 4) == 0:

--- a/xnlbd/track/elements.py
+++ b/xnlbd/track/elements.py
@@ -332,6 +332,13 @@ class ModulatedHenonmap(BeamElement):
         Number of tunes available in the tune arrays, if a particle is tracked
         above that number, a mod operator is used to roll-over the array. If the
         particle has negative at_turn value, the array is rolled backwards.
+    n_par_multipoles: int
+        Number of different multipole strengths provided. It is evaluated 
+        automatically from the length of the multipole_coeffs array provided.
+        It is used then at runtime to apply the same loop of strenghts to the
+        according turns via modulo operator. If only a single multipole strength
+        is provided, this value is 1, and the same strength is applied to all 
+        turns.
     norm: int
         1 if input coordinates are already normalised, 0 if not.
 

--- a/xnlbd/track/elements_src/henonmap.h
+++ b/xnlbd/track/elements_src/henonmap.h
@@ -1,5 +1,5 @@
-#ifndef XTRACK_HENONMAP_H
-#define XTRACK_HENONMAP_H
+#ifndef XNLBD_HENONMAP_H
+#define XNLBD_HENONMAP_H
 
 
 /*gpufun*/
@@ -200,4 +200,4 @@ void Henonmap_track_local_particle(HenonmapData el, LocalParticle* part0){
 
 }
 
-#endif /* XTRACK_HENONMAP_H */
+#endif /* XNLBD_HENONMAP_H */

--- a/xnlbd/track/elements_src/modulatedhenonmap.h
+++ b/xnlbd/track/elements_src/modulatedhenonmap.h
@@ -1,9 +1,10 @@
-#ifndef XTRACK_MODULATEDHENONMAP_H
-#define XTRACK_MODULATEDHENONMAP_H
+#ifndef XNLBD_MODULATEDHENONMAP_H
+#define XNLBD_MODULATEDHENONMAP_H
 
 /*gpufun*/
 void ModulatedHenonmap_track_local_particle(ModulatedHenonmapData el, LocalParticle* part0){
     int const n_turns = ModulatedHenonmapData_get_n_turns(el);
+    int const n_par_multipoles = ModulatedHenonmapData_get_n_par_multipoles(el);
 
     int const n_fx_coeffs = ModulatedHenonmapData_get_n_fx_coeffs(el);
     int const n_fy_coeffs = ModulatedHenonmapData_get_n_fy_coeffs(el);
@@ -30,6 +31,7 @@ void ModulatedHenonmap_track_local_particle(ModulatedHenonmapData el, LocalParti
         double py = LocalParticle_get_py(part);
         double delta = LocalParticle_get_delta(part);
         int at_turn = LocalParticle_get_at_turn(part);
+        int at_turn_multipole = LocalParticle_get_at_turn(part);
 
         if(at_turn >= n_turns)
         {
@@ -41,6 +43,18 @@ void ModulatedHenonmap_track_local_particle(ModulatedHenonmapData el, LocalParti
             {
                 at_turn += n_turns;
             }while(at_turn < 0);
+        }
+
+        if (at_turn_multipole >= n_par_multipoles)
+        {
+            at_turn_multipole = at_turn_multipole % n_par_multipoles;
+        }
+        if (at_turn_multipole < 0)
+        {
+            do
+            {
+                at_turn_multipole += n_par_multipoles;
+            } while (at_turn_multipole < 0);
         }
 
         #ifdef XSUITE_BACKTRACK
@@ -117,7 +131,7 @@ void ModulatedHenonmap_track_local_particle(ModulatedHenonmapData el, LocalParti
         double fx = 0;
         for (int i = 0; i < n_fx_coeffs; i++)
         {
-            double prod = ModulatedHenonmapData_get_fx_coeffs(el, n_fx_coeffs * at_turn + i) * multipole_scale;
+            double prod = ModulatedHenonmapData_get_fx_coeffs(el, n_fx_coeffs * at_turn_multipole + i) * multipole_scale;
             int x_power = ModulatedHenonmapData_get_fx_x_exps(el, i);
             int y_power = ModulatedHenonmapData_get_fx_y_exps(el, i);
             for (int j = 0; j < x_power; j++)
@@ -133,7 +147,7 @@ void ModulatedHenonmap_track_local_particle(ModulatedHenonmapData el, LocalParti
         double fy = 0;
         for (int i = 0; i < n_fy_coeffs; i++)
         {
-            double prod = ModulatedHenonmapData_get_fy_coeffs(el, n_fy_coeffs * at_turn + i) * multipole_scale;
+            double prod = ModulatedHenonmapData_get_fy_coeffs(el, n_fy_coeffs * at_turn_multipole + i) * multipole_scale;
             int x_power = ModulatedHenonmapData_get_fy_x_exps(el, i);
             int y_power = ModulatedHenonmapData_get_fy_y_exps(el, i);
             for (int j = 0; j < x_power; j++)
@@ -197,4 +211,4 @@ void ModulatedHenonmap_track_local_particle(ModulatedHenonmapData el, LocalParti
 
 }
 
-#endif /* XTRACK_MODULATEDHENONMAP_H */
+#endif /* XNLBD_MODULATEDHENONMAP_H */

--- a/xnlbd/track/modulations.py
+++ b/xnlbd/track/modulations.py
@@ -1,23 +1,28 @@
 import numpy as np
 
+# Amplitude of different 50 Hz harmonics measured in the SPS tune modulation 
+# as described in
 # REF: https://journals.aps.org/pre/abstract/10.1103/PhysRevE.57.3432
+
+SPS_REV_FREQ_IN_TURNS = 868.12
+
 SPS_COEFFICIENTS = np.array(
     [1.000e-4, 0.218e-4, 0.708e-4, 0.254e-4, 0.100e-4, 0.078e-4, 0.218e-4]
 )
 SPS_MODULATION = np.array(
     [
-        1 * (2 * np.pi / 868.12),
-        2 * (2 * np.pi / 868.12),
-        3 * (2 * np.pi / 868.12),
-        6 * (2 * np.pi / 868.12),
-        7 * (2 * np.pi / 868.12),
-        10 * (2 * np.pi / 868.12),
-        12 * (2 * np.pi / 868.12),
+        1 * (2 * np.pi / SPS_REV_FREQ_IN_TURNS),
+        2 * (2 * np.pi / SPS_REV_FREQ_IN_TURNS),
+        3 * (2 * np.pi / SPS_REV_FREQ_IN_TURNS),
+        6 * (2 * np.pi / SPS_REV_FREQ_IN_TURNS),
+        7 * (2 * np.pi / SPS_REV_FREQ_IN_TURNS),
+        10 * (2 * np.pi / SPS_REV_FREQ_IN_TURNS),
+        12 * (2 * np.pi / SPS_REV_FREQ_IN_TURNS),
     ]
 )
 
 
-def make_sps_modulation(base_tune, epsilon, times=np.arange(86812)):
+def make_sps_modulation(base_tune, epsilon, turns=np.arange(86812)):
     """Get the SPS modulation for the given tune and epsilon. Units are in
     radians. REF: https://journals.aps.org/pre/abstract/10.1103/PhysRevE.57.3432
 
@@ -28,16 +33,17 @@ def make_sps_modulation(base_tune, epsilon, times=np.arange(86812)):
     epsilon : float
         The modulation amplitude. Usually between 0 (no modulation) and 
         64.0 (strong modulation).
-    times : np.ndarray, optional
-        The times at which to calculate the modulation. Default is np.arange(86812).
+    turns : np.ndarray, optional
+        The given turns at which to calculate the modulation. Default is
+        np.arange(86812).
 
     Returns:
     --------
     tunes : np.ndarray
         The modulated tunes in radians.
     """
-    tunes = np.zeros_like(times, dtype=float)
+    tunes = np.zeros_like(turns, dtype=float)
     for i, modulation in enumerate(SPS_MODULATION):
-        tunes += SPS_COEFFICIENTS[i] * np.cos(modulation * times)
+        tunes += SPS_COEFFICIENTS[i] * np.cos(modulation * turns)
     tunes = base_tune * (1 + epsilon * tunes)
     return tunes

--- a/xnlbd/track/modulations.py
+++ b/xnlbd/track/modulations.py
@@ -1,0 +1,43 @@
+import numpy as np
+
+# REF: https://journals.aps.org/pre/abstract/10.1103/PhysRevE.57.3432
+SPS_COEFFICIENTS = np.array(
+    [1.000e-4, 0.218e-4, 0.708e-4, 0.254e-4, 0.100e-4, 0.078e-4, 0.218e-4]
+)
+SPS_MODULATION = np.array(
+    [
+        1 * (2 * np.pi / 868.12),
+        2 * (2 * np.pi / 868.12),
+        3 * (2 * np.pi / 868.12),
+        6 * (2 * np.pi / 868.12),
+        7 * (2 * np.pi / 868.12),
+        10 * (2 * np.pi / 868.12),
+        12 * (2 * np.pi / 868.12),
+    ]
+)
+
+
+def make_sps_modulation(base_tune, epsilon, times=np.arange(86812)):
+    """Get the SPS modulation for the given tune and epsilon. Units are in
+    radians. REF: https://journals.aps.org/pre/abstract/10.1103/PhysRevE.57.3432
+
+    Arguments:
+    ----------
+    base_tune : float
+        The base tune for the modulation.
+    epsilon : float
+        The modulation amplitude. Usually between 0 (no modulation) and 
+        64.0 (strong modulation).
+    times : np.ndarray, optional
+        The times at which to calculate the modulation. Default is np.arange(86812).
+
+    Returns:
+    --------
+    tunes : np.ndarray
+        The modulated tunes in radians.
+    """
+    tunes = np.zeros_like(times, dtype=float)
+    for i, modulation in enumerate(SPS_MODULATION):
+        tunes += SPS_COEFFICIENTS[i] * np.cos(modulation * times)
+    tunes = base_tune * (1 + epsilon * tunes)
+    return tunes


### PR DESCRIPTION
There was actually a couple of missing elements in the ModulatedHenonMap.
This is actually the version I have been using so far.

Note the extra changes to make the loop over different indices for the modulations and for the kick coefficients.

Also other minor changes:

- add a little function reporting the "standard" SPS modulation for the Hénon map;
- change the header guards in the c source to the new package name